### PR TITLE
Improve button text contrast on packing list

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -21,8 +21,8 @@ export function Button({
         {
           'bg-blue-600 text-white hover:bg-blue-700 shadow-md': variant === 'primary',
           'bg-gray-200 text-gray-900 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600': variant === 'secondary',
-          'border border-gray-300 bg-transparent text-gray-900 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-100 dark:border-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-100': variant === 'outline',
-          'text-gray-900 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-100 dark:hover:bg-gray-800 dark:hover:text-gray-100': variant === 'ghost',
+          'border border-gray-300 bg-white text-black hover:bg-gray-50 hover:text-black dark:text-gray-100 dark:border-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-100': variant === 'outline',
+          'text-black hover:bg-gray-100 hover:text-black dark:text-gray-100 dark:hover:bg-gray-800 dark:hover:text-gray-100': variant === 'ghost',
         },
         {
           'h-8 px-3 text-sm': size === 'sm',


### PR DESCRIPTION
Improve text contrast for 'Back' and 'Add Custom List' buttons on the Packing List page by ensuring black text on white backgrounds.

---
<a href="https://cursor.com/background-agent?bcId=bc-4df91e3b-b826-4624-a1c4-588ba45a869c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4df91e3b-b826-4624-a1c4-588ba45a869c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

