### PR TITLE
Remove "Value" from trip selections

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -146,7 +146,7 @@ export default function Home() {
                 </div>
                 <Select
                   options={[
-                    { value: '', label: 'Value' },
+                    { value: '', label: 'Select duration' },
                     { value: '1', label: '1 day' },
                     { value: '2', label: '2 days' },
                     { value: '3', label: '3 days' },
@@ -173,7 +173,7 @@ export default function Home() {
                 </div>
                 <Select
                   options={[
-                    { value: '', label: 'Value' },
+                    { value: '', label: 'Select trip type' },
                     ...tripTypes.slice(1)
                   ]}
                   value={formData.tripType}


### PR DESCRIPTION
Replace "Value" with descriptive placeholder text in "Trip Duration" and "Trip Type" selection boxes to improve user clarity.

---
<a href="https://cursor.com/background-agent?bcId=bc-b29464cf-ff92-4e4e-9fba-be4400859fb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b29464cf-ff92-4e4e-9fba-be4400859fb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

