### PR TITLE
Fix implementation error

### DIFF
--- a/src/app/api/cities/route.ts
+++ b/src/app/api/cities/route.ts
@@ -11,28 +11,30 @@ interface CityResult {
   displayName: string
 }
 
+interface GeocodingResult {
+  id: number
+  name: string
+  latitude: number
+  longitude: number
+  elevation?: number
+  feature_code: string
+  country_code: string
+  admin1_id?: number
+  admin2_id?: number
+  admin3_id?: number
+  admin4_id?: number
+  timezone: string
+  population?: number
+  country: string
+  country_id: number
+  admin1?: string
+  admin2?: string
+  admin3?: string
+  admin4?: string
+}
+
 interface GeocodingResponse {
-  results?: Array<{
-    id: number
-    name: string
-    latitude: number
-    longitude: number
-    elevation?: number
-    feature_code: string
-    country_code: string
-    admin1_id?: number
-    admin2_id?: number
-    admin3_id?: number
-    admin4_id?: number
-    timezone: string
-    population?: number
-    country: string
-    country_id: number
-    admin1?: string
-    admin2?: string
-    admin3?: string
-    admin4?: string
-  }>
+  results?: Array<GeocodingResult>
 }
 
 // Cache for city search results
@@ -207,7 +209,7 @@ async function searchCities(query: string): Promise<CityResult[]> {
       
       // Sort by importance: capital cities first, then major cities, then by population
       filteredResults = countryCities.sort((a, b) => {
-        const getImportanceScore = (result: any) => {
+        const getImportanceScore = (result: GeocodingResult) => {
           if (result.feature_code === 'PPLC') return 1000000 // Capital
           if (result.feature_code === 'PPLA') return 500000  // Major city
           if (result.feature_code === 'PPLA2') return 100000 // Secondary city


### PR DESCRIPTION
Refactor geocoding result types and update `getImportanceScore` parameter to fix a TypeScript compilation error.

The original code used `any` for the `result` parameter in `getImportanceScore` and an inline type for `GeocodingResponse['results']`. This PR extracts the geocoding result into a dedicated `GeocodingResult` interface and uses it to correctly type the parameter, resolving the `any` type error and improving type safety.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf9b57a5-e4a5-43f2-a44f-8b8a035e4bf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bf9b57a5-e4a5-43f2-a44f-8b8a035e4bf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

