### PR TITLE
Fix weather data loading issue

### DIFF
--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -154,7 +154,7 @@ async function fetchWeatherData(city: string, country: string) {
     
     try {
       // Construct weather API URL to get exactly 7 days starting from today
-      const weatherUrl = `https://api.open-meteo.com/v1/forecast?latitude=${coordinates.lat}&longitude=${coordinates.lon}&daily=temperature_2m_max,temperature_2m_min,weather_code,precipitation_probability_max&timezone=auto&forecast_days=7&start_date=${new Date().toISOString().split('T')[0]}`
+      const weatherUrl = `https://api.open-meteo.com/v1/forecast?latitude=${coordinates.lat}&longitude=${coordinates.lon}&daily=temperature_2m_max,temperature_2m_min,weather_code,precipitation_probability_max&timezone=auto&forecast_days=7`
       
       const weatherResponse = await fetch(weatherUrl, {
         signal: controller.signal,
@@ -219,8 +219,7 @@ export async function GET(request: NextRequest) {
       )
     }
     
-    // Explicitly set start_date to today to prevent historical data inclusion
-    // This ensures the forecast always starts from today and shows exactly 7 days
+    // Get 7-day forecast starting from today
     
     const weatherData = await fetchWeatherData(city, country)
     


### PR DESCRIPTION
Remove the `start_date` parameter from the Open-Meteo API call to fix weather data loading.

The Open-Meteo API was rejecting requests when `start_date` was used without `end_date`, causing the website to fail loading weather data. Removing the `start_date` parameter allows the API to default to today's date, resolving the issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-397f349f-186d-4c5d-9609-3c1085e79fcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-397f349f-186d-4c5d-9609-3c1085e79fcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

