### PR TITLE
Fix deployment error from screenshot

### DIFF
--- a/src/hooks/useAsyncState.ts
+++ b/src/hooks/useAsyncState.ts
@@ -11,7 +11,7 @@ export interface UseAsyncStateReturn<T> extends AsyncState<T> {
   reset: () => void
 }
 
-export function useAsyncState<T = any>(
+export function useAsyncState<T = unknown>(
   initialData: T | null = null
 ): UseAsyncStateReturn<T> {
   const [state, setState] = useState<AsyncState<T>>({

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -16,6 +16,7 @@ export function useDebounce<T>(value: T, delay: number): T {
   return debouncedValue
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function useDebouncedCallback<T extends (...args: any[]) => any>(
   callback: T,
   delay: number

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -71,6 +71,7 @@ export const commonStyles = {
 import { TemperatureUnit } from '@/types'
 
 // Debounce function for performance optimization
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function debounce<T extends (...args: any[]) => any>(
   func: T,
   wait: number
@@ -89,6 +90,7 @@ export function debounce<T extends (...args: any[]) => any>(
 }
 
 // Throttle function for performance optimization
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function throttle<T extends (...args: any[]) => any>(
   func: T,
   limit: number
@@ -121,7 +123,7 @@ export function safeJsonParse<T>(
 
 // Safe JSON stringify
 export function safeJsonStringify(
-  obj: any, 
+  obj: unknown, 
   fallback: string = '{}'
 ): string {
   try {


### PR DESCRIPTION
Fix TypeScript compilation errors and ESLint warnings by refining `any` types and adding specific ESLint disable comments for generic utility functions.

Deployment was failing due to strict TypeScript compilation and ESLint rules (`@typescript-eslint/no-explicit-any`). This PR replaces explicit `any` with `unknown` where appropriate and adds targeted ESLint disable comments for generic utility functions (`debounce`, `throttle`, `useDebouncedCallback`) where `any` is necessary to maintain their flexibility without causing compilation errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-ede54292-c43a-43cd-90ee-5e8ea12f878c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ede54292-c43a-43cd-90ee-5e8ea12f878c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

